### PR TITLE
feat: adress reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.0.0-beta.9
+
+### Added
+
+- `WalletInitParams.reuseAddresses` — optional `boolean` (default `false`); passed to `WasmWallet` as `reuse_addresses` to pin addresses per keychain instead of rotating automatically
+- `WalletInitParams.vanillaKeychain` — optional `number | null` (default `0`); controls the BIP32 keychain index used for the vanilla (BTC) wallet
+- `WalletInitParams.maxAllocationsPerUtxo` — optional `number` (default `5`); forwarded to `WasmWallet` as `max_allocations_per_utxo`
+- `WasmRgbLibBinding.rotateVanillaAddress()` — rotates the pinned vanilla address (`rotate_address(0)`); requires wallet created with `reuseAddresses: true`
+- `WasmRgbLibBinding.rotateColoredAddress()` — rotates the pinned colored address (`rotate_address(1)`); requires wallet created with `reuseAddresses: true`
+- `WalletManager` forwards all three new params to `WasmRgbLibBinding.create()`
+- Jest test suite (`tests/wallet-init-params.test.ts`) covering default values and forwarding of all new fields, plus `rotateVanillaAddress` / `rotateColoredAddress` behavior
+
+### Changed
+
+- `rotateAddress(keychain: number)` removed in favor of the explicit `rotateVanillaAddress()` / `rotateColoredAddress()` split, matching the Node.js rgb-lib binding API
+
 ## 1.0.0
 
 Initial release of `@utexo/rgb-sdk-web` — a browser-first rewrite of the RGB SDK.

--- a/Readme.md
+++ b/Readme.md
@@ -39,10 +39,15 @@ import { UTEXOWallet, generateKeys } from '@utexo/rgb-sdk-web';
 const keys = await generateKeys('testnet');
 
 const wallet = new UTEXOWallet(keys.mnemonic, { network: 'testnet' });
-await wallet.initialize(); 
+await wallet.initialize();
 
 const address = await wallet.getAddress();
 const balance = await wallet.getBtcBalance();
+
+// Optional: enable address reuse — getAddress() returns the same address on every call
+// instead of advancing the derivation index. Default: false.
+const reuseWallet = new UTEXOWallet(keys.mnemonic, { network: 'testnet', reuseAddresses: true });
+await reuseWallet.initialize();
 ```
 
 ---
@@ -79,7 +84,6 @@ const ifa = await wallet.issueAssetIfa({
   name: 'My IFA',
   amounts: [500],
   inflationAmounts: [1000],
-  replaceRightsNum: 1,
   precision: 0,
   rejectListUrl: null,
 });
@@ -144,6 +148,21 @@ const unsignedPsbt = await wallet.sendBtcBegin({
 const signedPsbt = await wallet.signPsbt(unsignedPsbt);
 const txid = await wallet.sendBtcEnd({ signedPsbt });
 ```
+
+### Address Reuse and Rotation
+
+By default, each call to `getAddress()` advances the derivation index so a fresh receive address is returned. Pass `reuseAddresses: true` to `WalletManager.create()` to keep returning the same address — useful for testing or scenarios where address rotation is handled externally.
+
+The address can be rotated manually at any time:
+
+```typescript
+// Advance to the next vanilla (BTC) receive address
+const newVanilla = await wallet.rotateVanillaAddress();
+
+// Advance to the next colored (RGB) receive address
+const newColored = await wallet.rotateColoredAddress();
+```
+
 
 ### Decode an RGB Invoice
 
@@ -222,6 +241,22 @@ await restoreUtxoWalletFromVss({
 
 ---
 
+## Consignment Validation
+
+```typescript
+import { validateConsignmentOffchain } from '@utexo/rgb-sdk-web';
+
+// Validate a consignment before the witness tx is broadcast (no indexer needed)
+const result = await validateConsignmentOffchain({
+  consignmentBytes: new Uint8Array(/* strict-encoded bytes */),
+  txid: 'the-witness-txid',
+  network: 'testnet',
+});
+console.log(result); // { valid: boolean, warnings?, error?, details? }
+```
+
+---
+
 ## Key Utilities
 
 ```typescript
@@ -284,10 +319,12 @@ Used automatically when no custom endpoint is passed:
 
 | Method | Description |
 |--------|-------------|
-| `WalletManager.create(params)` | Async factory — loads WASM, creates wallet |
+| `WalletManager.create(params)` | Async factory — loads WASM, creates wallet. Pass `reuseAddresses: true` to disable address rotation |
 | `goOnline(indexerUrl?)` | Connect to indexer (required before network ops) |
 | `registerWallet()` | Get initial address + BTC balance snapshot |
 | `getAddress()` | New Bitcoin deposit address |
+| `rotateVanillaAddress()` | Rotate to next vanilla (BTC) receive address |
+| `rotateColoredAddress()` | Rotate to next colored (RGB) receive address |
 | `getBtcBalance()` | BTC balance (`vanilla` + `colored`) |
 | `getXpub()` | Vanilla and colored xpubs |
 | `getNetwork()` | Current network name |
@@ -337,10 +374,11 @@ Used automatically when no custom endpoint is passed:
 
 ## TypeScript
 
-All public types are exported. The raw WASM JSON shapes (snake_case) are available under the `WasmJson` namespace:
+All public types are exported. The raw WASM JSON shapes are available under the `WasmJson` namespace. Fields use **camelCase** (the SDK is compiled with the `camel_case` Cargo feature):
 
 ```typescript
 import type { WasmJson } from '@utexo/rgb-sdk-web';
 
-type RawRecipient = WasmJson.Recipient;  // { recipient_id, assignment, ... }
+type RawRecipient = WasmJson.Recipient;  // { recipientId, witnessData, assignment, transportEndpoints }
+type RawInvoice   = WasmJson.InvoiceData; // { recipientId, assetId, assignment, transportEndpoints, ... }
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,7 @@ export default {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@noble/hashes/sha2$': '<rootDir>/node_modules/@noble/hashes/sha2.js',
+    '^@utexo/rgb-lib-wasm$': '<rootDir>/tests/__mocks__/rgb-lib-wasm.ts',
   },
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/**/index.ts'],
   testTimeout: 30000, // Increased timeout for crypto operations

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@bitcoindevkit/bdk-wallet-web": "^0.2.0",
     "@noble/hashes": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-lib-wasm": "file:/Users/yuriibandrivskyi/Desktop/utexo/rgb-lib-wasm/bindings/wasm/pkg",
-    "@utexo/rgb-sdk-core": "file:../rgb-sdk-core",
+    "@utexo/rgb-lib-wasm": "1.0.0-beta.2",
+    "@utexo/rgb-sdk-core": "1.0.0-beta.3",
     "bitcoinjs-lib": "^6.1.7"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@bitcoindevkit/bdk-wallet-web": "^0.2.0",
     "@noble/hashes": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-lib-wasm": "1.0.0-beta.1",
-    "@utexo/rgb-sdk-core": "1.0.0-beta.2",
+    "@utexo/rgb-lib-wasm": "file:/Users/yuriibandrivskyi/Desktop/utexo/rgb-lib-wasm/bindings/wasm/pkg",
+    "@utexo/rgb-sdk-core": "file:../rgb-sdk-core",
     "bitcoinjs-lib": "^6.1.7"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@bitcoindevkit/bdk-wallet-web": "^0.2.0",
     "@noble/hashes": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-lib-wasm": "1.0.0-beta.1",
+    "@utexo/rgb-lib-wasm": "file:/Users/yuriibandrivskyi/Desktop/utexo/rgb-lib-wasm/bindings/wasm/pkg",
     "@utexo/rgb-sdk-core": "1.0.0-beta.2",
     "bitcoinjs-lib": "^6.1.7"
   },

--- a/src/binding/WasmRgbLibBinding.ts
+++ b/src/binding/WasmRgbLibBinding.ts
@@ -8,8 +8,8 @@
 import {
   WasmWallet,
   WasmInvoice,
-  generate_keys,
-  restore_keys,
+  generateKeys as wasmGenerateKeys,
+  restoreKeys as wasmRestoreKeys,
 } from '@utexo/rgb-lib-wasm';
 import { initWasm } from '../wasm/init';
 import {
@@ -67,25 +67,22 @@ import type {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** rgb-lib WASM expects serde snake_case `Recipient` objects (see WasmTypes). */
+/** rgb-lib WASM expects camelCase `Recipient` objects (see WasmTypes). */
 function batchRecipientToWasm(r: BatchRecipient): WasmRecipient {
   const wd = r.witnessData;
-  const witness: WasmRecipient['witness_data'] =
+  const witness: WasmRecipient['witnessData'] =
     wd == null
       ? null
       : {
-          amount_sat:
-            typeof wd.amountSat === 'string'
-              ? Number(wd.amountSat)
-              : Number(wd.amountSat),
+          amountSat: String(wd.amountSat),
           blinding: wd.blinding ?? null,
         };
 
   return {
-    recipient_id: r.recipientId,
-    witness_data: witness,
+    recipientId: r.recipientId,
+    witnessData: witness,
     assignment: { Fungible: r.assignment.Fungible },
-    transport_endpoints: r.transportEndpoints,
+    transportEndpoints: r.transportEndpoints,
   };
 }
 
@@ -286,7 +283,7 @@ export const generateKeys = async (
   network: string = 'regtest'
 ): Promise<RgbLibGeneratedKeys> => {
   await initWasm();
-  return generate_keys(mapNetwork(network)) as RgbLibGeneratedKeys;
+  return wasmGenerateKeys(mapNetwork(network)) as RgbLibGeneratedKeys;
 };
 
 export const restoreKeys = async (
@@ -294,7 +291,7 @@ export const restoreKeys = async (
   mnemonic: string
 ): Promise<RgbLibGeneratedKeys> => {
   await initWasm();
-  return restore_keys(mapNetwork(network), mnemonic) as RgbLibGeneratedKeys;
+  return wasmRestoreKeys(mapNetwork(network), mnemonic) as RgbLibGeneratedKeys;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -375,6 +372,9 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     network?: string | number;
     transportEndpoint?: string;
     indexerUrl?: string;
+    reuseAddresses?: boolean;
+    vanillaKeychain?: number | null;
+    maxAllocationsPerUtxo?: number;
   }): Promise<WasmRgbLibBinding> {
     if (!params.mnemonic) {
       throw new ValidationError(
@@ -387,16 +387,18 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
     const network = String(params.network ?? 'regtest');
     const walletData: WasmWalletData = {
-      data_dir: `:memory:/${network}`,
-      bitcoin_network: mapNetwork(network),
-      database_type: 'Sqlite',
-      max_allocations_per_utxo: 5,
-      account_xpub_vanilla: params.xpubVan,
-      account_xpub_colored: params.xpubCol,
+      dataDir: `:memory:/${network}`,
+      bitcoinNetwork: mapNetwork(network),
+      databaseType: 'Sqlite',
+      maxAllocationsPerUtxo: params.maxAllocationsPerUtxo ?? 5,
+      accountXpubVanilla: params.xpubVan,
+      accountXpubColored: params.xpubCol,
       mnemonic: params.mnemonic,
-      master_fingerprint: params.masterFingerprint,
-      vanilla_keychain: 0,
-      supported_schemas:
+      masterFingerprint: params.masterFingerprint,
+      vanillaKeychain:
+        params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0,
+      reuseAddresses: params.reuseAddresses ?? false,
+      supportedSchemas:
         mapNetwork(network) === 'Mainnet' ? ['Nia'] : ['Nia', 'Ifa'],
     };
 
@@ -423,7 +425,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   private async ensureOnline(): Promise<WasmOnline> {
     if (this.online) return this.online;
     try {
-      this.online = (await this.wallet.go_online(
+      this.online = (await this.wallet.goOnline(
         false,
         this.indexerUrl
       )) as WasmOnline;
@@ -440,7 +442,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   /** IRgbLibBinding: fire-and-forget online connection. */
   getOnline(): void {
     this.ensureOnline().catch((e) =>
-      logger.warn('WasmRgbLibBinding: go_online failed:', e)
+      logger.warn('WasmRgbLibBinding: goOnline failed:', e)
     );
   }
 
@@ -459,25 +461,37 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   registerWallet(): { address: string; btcBalance: BtcBalance } {
-    const address = this.wallet.get_address();
-    const btcBalance = this.wallet.get_btc_balance() as BtcBalance;
+    const address = this.wallet.getAddress();
+    const btcBalance = this.wallet.getBtcBalance() as BtcBalance;
     return { address, btcBalance };
   }
 
   // ─── Balance & address ──────────────────────────────────────────────────────
 
   async getBtcBalance(): Promise<BtcBalance> {
-    return this.wallet.get_btc_balance() as BtcBalance;
+    return this.wallet.getBtcBalance() as BtcBalance;
   }
 
   async getAddress(): Promise<string> {
-    return this.wallet.get_address();
+    return this.wallet.getAddress();
+  }
+
+  async rotateVanillaAddress(): Promise<string> {
+    throw new WalletError(
+      'rotateVanillaAddress is not available in the current rgb-lib-wasm build.'
+    );
+  }
+
+  async rotateColoredAddress(): Promise<string> {
+    throw new WalletError(
+      'rotateColoredAddress is not available in the current rgb-lib-wasm build.'
+    );
   }
 
   // ─── Unspents ───────────────────────────────────────────────────────────────
 
   async listUnspents(): Promise<Unspent[]> {
-    const raw: any[] = this.wallet.list_unspents(false) as any[];
+    const raw: any[] = this.wallet.listUnspents(false) as any[];
     return raw.map((unspent) => {
       const rgbAllocs = unspent.rgb_allocations ?? unspent.rgbAllocations ?? [];
       return {
@@ -518,7 +532,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     params: CreateUtxosBeginRequestModel
   ): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.create_utxos_begin(
+    return this.wallet.createUtxosBegin(
       online,
       params.upTo ?? false,
       params.num ?? undefined,
@@ -530,7 +544,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async createUtxosEnd(params: CreateUtxosEndRequestModel): Promise<number> {
     const online = await this.ensureOnline();
-    return this.wallet.create_utxos_end(
+    return this.wallet.createUtxosEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -573,26 +587,28 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     const transportEndpoints = (raw.transport_endpoints ??
       raw.transportEndpoints) as string[] | undefined;
 
-    const witnessData: WasmRecipient['witness_data'] =
+    const witnessData: WasmRecipient['witnessData'] =
       params.witnessData != null
         ? {
-            amount_sat: String(params.witnessData.amountSat),
+            amountSat: String(params.witnessData.amountSat),
             blinding: params.witnessData.blinding ?? null,
           }
         : null;
 
     const recipient: WasmRecipient = {
-      recipient_id: String(raw.recipient_id ?? raw.recipientId ?? ''),
-      witness_data: witnessData,
+      recipientId: String(raw.recipient_id ?? raw.recipientId ?? ''),
+      witnessData,
       assignment: { Fungible: amount },
-      transport_endpoints: transportEndpoints ?? [],
+      transportEndpoints: transportEndpoints ?? [],
     };
+
+    const recipientMap = { [assetId]: [recipient] } as WasmRecipientMap;
 
     const online = await this.ensureOnline();
 
-    return this.wallet.send_begin(
+    return this.wallet.sendBegin(
       online,
-      { [assetId]: [recipient] } as WasmRecipientMap,
+      recipientMap,
       params.donation ?? true,
       BigInt(Math.round(params.feeRate ?? 1)),
       params.minConfirmations ?? 1
@@ -614,7 +630,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
       );
     }
 
-    return this.wallet.send_begin(
+    return this.wallet.sendBegin(
       online,
       sdkRecipientMapToWasm(params.recipientMap),
       params.donation ?? true,
@@ -625,7 +641,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendEnd(params: SendAssetEndRequestModel): Promise<SendResult> {
     const online = await this.ensureOnline();
-    const raw = await this.wallet.send_end(
+    const raw = await this.wallet.sendEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -637,7 +653,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendBtcBegin(params: SendBtcBeginRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.send_btc_begin(
+    return this.wallet.sendBtcBegin(
       online,
       params.address,
       BigInt(Math.round(params.amount)),
@@ -648,7 +664,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendBtcEnd(params: SendBtcEndRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.send_btc_end(
+    return this.wallet.sendBtcEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -661,7 +677,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     const assignment =
       params.amount != null ? { Fungible: params.amount } : 'Any';
 
-    const raw: unknown = this.wallet.blind_receive(
+    const raw: unknown = this.wallet.blindReceive(
       params.assetId ?? null,
       assignment,
       params.durationSeconds ?? null,
@@ -674,7 +690,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   async witnessReceive(params: InvoiceRequest): Promise<InvoiceReceiveData> {
     const assignment =
       params.amount != null ? { Fungible: params.amount } : 'Any';
-    const raw: unknown = this.wallet.witness_receive(
+    const raw: unknown = this.wallet.witnessReceive(
       params.assetId || null,
       assignment,
       params.durationSeconds ?? null,
@@ -713,12 +729,12 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   // ─── Assets ─────────────────────────────────────────────────────────────────
 
   async listAssets(): Promise<ListAssets> {
-    const raw = this.wallet.list_assets([]);
+    const raw = this.wallet.listAssets([]);
     return normalizeListAssets(raw);
   }
 
   async getAssetBalance(assetId: string): Promise<AssetBalance> {
-    const balance: Record<string, unknown> = this.wallet.get_asset_balance(
+    const balance: Record<string, unknown> = this.wallet.getAssetBalance(
       assetId
     ) as Record<string, unknown>;
     return {
@@ -735,7 +751,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async issueAssetNia(params: IssueAssetNiaRequestModel): Promise<AssetNIA> {
-    const raw = this.wallet.issue_asset_nia(
+    const raw = this.wallet.issueAssetNia(
       params.ticker,
       params.name,
       params.precision,
@@ -745,13 +761,12 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async issueAssetIfa(params: IssueAssetIfaRequestModel): Promise<AssetIfa> {
-    const raw = this.wallet.issue_asset_ifa(
+    const raw = this.wallet.issueAssetIfa(
       params.ticker,
       params.name,
       params.precision,
       params.amounts,
       params.inflationAmounts,
-      params.replaceRightsNum,
       params.rejectListUrl ?? null
     ) as Record<string, unknown>;
     return normalizeAssetIfa(raw);
@@ -761,7 +776,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async inflateBegin(params: InflateAssetIfaRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.inflate_begin(
+    return this.wallet.inflateBegin(
       online,
       params.assetId,
       params.inflationAmounts,
@@ -772,19 +787,19 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async inflateEnd(params: InflateEndRequestModel): Promise<OperationResult> {
     const online = await this.ensureOnline();
-    const raw = await this.wallet.inflate_end(online, params.signedPsbt);
+    const raw = await this.wallet.inflateEnd(online, params.signedPsbt);
     return normalizeBatchTxResult(raw);
   }
 
   // ─── Transfers & transactions ────────────────────────────────────────────────
 
   async listTransactions(): Promise<Transaction[]> {
-    const raw = this.wallet.list_transactions() as Record<string, unknown>[];
+    const raw = this.wallet.listTransactions() as Record<string, unknown>[];
     return raw.map((t) => normalizeTransaction(t));
   }
 
   async listTransfers(assetId?: string): Promise<Transfer[]> {
-    const raw = this.wallet.list_transfers(assetId ?? null) as Record<
+    const raw = this.wallet.listTransfers(assetId ?? null) as Record<
       string,
       unknown
     >[];
@@ -793,7 +808,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async failTransfers(params: FailTransfersRequest): Promise<boolean> {
     const online = await this.ensureOnline();
-    return this.wallet.fail_transfers(
+    return this.wallet.failTransfers(
       online,
       params.batchTransferIdx ?? null,
       params.noAssetOnly ?? false,
@@ -805,7 +820,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     batchTransferIdx?: number;
     noAssetOnly?: boolean;
   }): boolean {
-    return this.wallet.delete_transfers(
+    return this.wallet.deleteTransfers(
       params.batchTransferIdx ?? null,
       params.noAssetOnly ?? false
     );
@@ -815,8 +830,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async refreshWallet(): Promise<void> {
     const online = await this.ensureOnline();
-    const refreshed = await this.wallet.refresh(online, null, [], false);
-    return refreshed;
+    await this.wallet.refresh(online, null, [], false);
   }
 
   async syncWallet(): Promise<void> {
@@ -831,7 +845,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }): Promise<GetFeeEstimationResponse> {
     const online = await this.ensureOnline();
     try {
-      return await this.wallet.get_fee_estimation(online, params.blocks);
+      return await this.wallet.getFeeEstimation(online, params.blocks);
     } catch {
       logger.warn(
         'WasmRgbLibBinding: fee estimation unavailable, using default 2'
@@ -871,13 +885,13 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
    * WASM-specific: restore wallet state from raw backup bytes.
    */
   restoreFromBackupBytes(bytes: Uint8Array, password: string): void {
-    this.wallet.restore_backup(bytes, password);
+    this.wallet.restoreBackup(bytes, password);
   }
 
   // ─── VSS backup ─────────────────────────────────────────────────────────────
 
   configureVssBackup(config: VssBackupConfig): void {
-    this.wallet.configure_vss_backup(
+    this.wallet.configureVssBackup(
       config.serverUrl,
       config.storeId,
       config.signingKey
@@ -885,17 +899,16 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   disableVssAutoBackup(): void {
-    this.wallet.disable_vss_backup();
+    this.wallet.disableVssBackup();
   }
 
   async vssBackup(_config: VssBackupConfig): Promise<number> {
-    // Config must already be set via configureVssBackup before calling.
-    const version = await this.wallet.vss_backup();
+    const version = await this.wallet.vssBackup();
     return Number(version);
   }
 
   async vssBackupInfo(_config: VssBackupConfig): Promise<VssBackupInfo> {
-    const info: any = await this.wallet.vss_backup_info();
+    const info: any = await this.wallet.vssBackupInfo();
     return {
       backupExists: Boolean(info.backup_exists ?? info.backupExists),
       serverVersion: info.server_version ?? info.serverVersion ?? null,
@@ -904,7 +917,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async vssRestoreBackup(): Promise<void> {
-    await this.wallet.vss_restore_backup();
+    await this.wallet.vssRestoreBackup();
   }
 
   // ─── PSBT signing (built-in) ─────────────────────────────────────────────────
@@ -914,10 +927,10 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
    * Called by WasmSigner.signPsbtWithMnemonic (Phase 3).
    */
   signPsbt(unsignedPsbt: string): string {
-    return this.wallet.sign_psbt(unsignedPsbt);
+    return this.wallet.signPsbt(unsignedPsbt);
   }
 
   finalizePsbt(signedPsbt: string): string {
-    return this.wallet.finalize_psbt(signedPsbt);
+    return this.wallet.finalizePsbt(signedPsbt);
   }
 }

--- a/src/binding/WasmRgbLibBinding.ts
+++ b/src/binding/WasmRgbLibBinding.ts
@@ -375,6 +375,9 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     network?: string | number;
     transportEndpoint?: string;
     indexerUrl?: string;
+    reuseAddresses?: boolean;
+    vanillaKeychain?: number | null;
+    maxAllocationsPerUtxo?: number;
   }): Promise<WasmRgbLibBinding> {
     if (!params.mnemonic) {
       throw new ValidationError(
@@ -390,12 +393,13 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
       data_dir: `:memory:/${network}`,
       bitcoin_network: mapNetwork(network),
       database_type: 'Sqlite',
-      max_allocations_per_utxo: 5,
+      max_allocations_per_utxo: params.maxAllocationsPerUtxo ?? 5,
       account_xpub_vanilla: params.xpubVan,
       account_xpub_colored: params.xpubCol,
       mnemonic: params.mnemonic,
       master_fingerprint: params.masterFingerprint,
-      vanilla_keychain: 0,
+      vanilla_keychain: params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0,
+      reuse_addresses: params.reuseAddresses ?? false,
       supported_schemas:
         mapNetwork(network) === 'Mainnet' ? ['Nia'] : ['Nia', 'Ifa'],
     };
@@ -472,6 +476,14 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async getAddress(): Promise<string> {
     return this.wallet.get_address();
+  }
+
+  async rotateVanillaAddress(): Promise<string> {
+    return this.wallet.rotate_address(0);
+  }
+
+  async rotateColoredAddress(): Promise<string> {
+    return this.wallet.rotate_address(1);
   }
 
   // ─── Unspents ───────────────────────────────────────────────────────────────
@@ -751,7 +763,6 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
       params.precision,
       params.amounts,
       params.inflationAmounts,
-      params.replaceRightsNum,
       params.rejectListUrl ?? null
     ) as Record<string, unknown>;
     return normalizeAssetIfa(raw);

--- a/src/binding/WasmRgbLibBinding.ts
+++ b/src/binding/WasmRgbLibBinding.ts
@@ -398,7 +398,8 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
       account_xpub_colored: params.xpubCol,
       mnemonic: params.mnemonic,
       master_fingerprint: params.masterFingerprint,
-      vanilla_keychain: params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0,
+      vanilla_keychain:
+        params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0,
       reuse_addresses: params.reuseAddresses ?? false,
       supported_schemas:
         mapNetwork(network) === 'Mainnet' ? ['Nia'] : ['Nia', 'Ifa'],

--- a/src/binding/WasmRgbLibBinding.ts
+++ b/src/binding/WasmRgbLibBinding.ts
@@ -8,8 +8,9 @@
 import {
   WasmWallet,
   WasmInvoice,
-  generate_keys,
-  restore_keys,
+  generateKeys as wasmGenerateKeys,
+  restoreKeys as wasmRestoreKeys,
+  validateConsignmentOffchain as wasmValidateConsignmentOffchain,
 } from '@utexo/rgb-lib-wasm';
 import { initWasm } from '../wasm/init';
 import {
@@ -67,25 +68,22 @@ import type {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** rgb-lib WASM expects serde snake_case `Recipient` objects (see WasmTypes). */
+/** rgb-lib WASM expects camelCase `Recipient` objects (see WasmTypes). */
 function batchRecipientToWasm(r: BatchRecipient): WasmRecipient {
   const wd = r.witnessData;
-  const witness: WasmRecipient['witness_data'] =
+  const witness: WasmRecipient['witnessData'] =
     wd == null
       ? null
       : {
-          amount_sat:
-            typeof wd.amountSat === 'string'
-              ? Number(wd.amountSat)
-              : Number(wd.amountSat),
+          amountSat: String(wd.amountSat),
           blinding: wd.blinding ?? null,
         };
 
   return {
-    recipient_id: r.recipientId,
-    witness_data: witness,
+    recipientId: r.recipientId,
+    witnessData: witness,
     assignment: { Fungible: r.assignment.Fungible },
-    transport_endpoints: r.transportEndpoints,
+    transportEndpoints: r.transportEndpoints,
   };
 }
 
@@ -286,7 +284,7 @@ export const generateKeys = async (
   network: string = 'regtest'
 ): Promise<RgbLibGeneratedKeys> => {
   await initWasm();
-  return generate_keys(mapNetwork(network)) as RgbLibGeneratedKeys;
+  return wasmGenerateKeys(mapNetwork(network)) as RgbLibGeneratedKeys;
 };
 
 export const restoreKeys = async (
@@ -294,7 +292,27 @@ export const restoreKeys = async (
   mnemonic: string
 ): Promise<RgbLibGeneratedKeys> => {
   await initWasm();
-  return restore_keys(mapNetwork(network), mnemonic) as RgbLibGeneratedKeys;
+  return wasmRestoreKeys(mapNetwork(network), mnemonic) as RgbLibGeneratedKeys;
+};
+
+/**
+ * Validate an RGB consignment offchain (no indexer needed).
+ *
+ * Takes raw consignment bytes (strict-encoded, not base64), the witness txid,
+ * and the network. Returns the validation result object from rgb-lib.
+ */
+export const validateConsignmentOffchain = async (params: {
+  consignmentBytes: Uint8Array;
+  txid: string;
+  network?: string;
+}): Promise<unknown> => {
+  await initWasm();
+  const raw = wasmValidateConsignmentOffchain(
+    params.consignmentBytes,
+    params.txid,
+    mapNetwork(params.network ?? 'regtest')
+  );
+  return raw;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -310,15 +328,6 @@ function mapNetwork(network: string): string {
   };
   return map[String(network).toLowerCase()] ?? 'Regtest';
 }
-
-// export const DEFAULT_TRANSPORT_ENDPOINTS: Record<Network, string> = {
-//   mainnet: 'rpcs://rgb-proxy-mainnet.utexo.com/json-rpc',
-//   testnet: 'rpcs://rgb-proxy-testnet3.utexo.com/json-rpc',
-//   testnet4: 'rpcs://proxy.iriswallet.com/0.2/json-rpc',
-//   signet: 'rpcs://proxy.iriswallet.com/0.2/json-rpc',
-//   utexo: 'rpcs://rgb-proxy-utexo.utexo.com/json-rpc',
-//   regtest: 'rpcs://proxy.iriswallet.com/0.2/json-rpc',
-// };
 
 export const DEFAULT_INDEXER_URLS: Record<Network, string> = {
   mainnet: 'https://esplora-mainnet.utexo.com',
@@ -390,18 +399,18 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
     const network = String(params.network ?? 'regtest');
     const walletData: WasmWalletData = {
-      data_dir: `:memory:/${network}`,
-      bitcoin_network: mapNetwork(network),
-      database_type: 'Sqlite',
-      max_allocations_per_utxo: params.maxAllocationsPerUtxo ?? 5,
-      account_xpub_vanilla: params.xpubVan,
-      account_xpub_colored: params.xpubCol,
+      dataDir: `:memory:/${network}`,
+      bitcoinNetwork: mapNetwork(network),
+      databaseType: 'Sqlite',
+      maxAllocationsPerUtxo: params.maxAllocationsPerUtxo ?? 5,
+      accountXpubVanilla: params.xpubVan,
+      accountXpubColored: params.xpubCol,
       mnemonic: params.mnemonic,
-      master_fingerprint: params.masterFingerprint,
-      vanilla_keychain:
+      masterFingerprint: params.masterFingerprint,
+      vanillaKeychain:
         params.vanillaKeychain !== undefined ? params.vanillaKeychain : 0,
-      reuse_addresses: params.reuseAddresses ?? false,
-      supported_schemas:
+      reuseAddresses: params.reuseAddresses ?? false,
+      supportedSchemas:
         mapNetwork(network) === 'Mainnet' ? ['Nia'] : ['Nia', 'Ifa'],
     };
 
@@ -428,7 +437,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   private async ensureOnline(): Promise<WasmOnline> {
     if (this.online) return this.online;
     try {
-      this.online = (await this.wallet.go_online(
+      this.online = (await this.wallet.goOnline(
         false,
         this.indexerUrl
       )) as WasmOnline;
@@ -445,7 +454,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   /** IRgbLibBinding: fire-and-forget online connection. */
   getOnline(): void {
     this.ensureOnline().catch((e) =>
-      logger.warn('WasmRgbLibBinding: go_online failed:', e)
+      logger.warn('WasmRgbLibBinding: goOnline failed:', e)
     );
   }
 
@@ -464,33 +473,33 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   registerWallet(): { address: string; btcBalance: BtcBalance } {
-    const address = this.wallet.get_address();
-    const btcBalance = this.wallet.get_btc_balance() as BtcBalance;
+    const address = this.wallet.getAddress();
+    const btcBalance = this.wallet.getBtcBalance() as BtcBalance;
     return { address, btcBalance };
   }
 
   // ─── Balance & address ──────────────────────────────────────────────────────
 
   async getBtcBalance(): Promise<BtcBalance> {
-    return this.wallet.get_btc_balance() as BtcBalance;
+    return this.wallet.getBtcBalance() as BtcBalance;
   }
 
   async getAddress(): Promise<string> {
-    return this.wallet.get_address();
+    return this.wallet.getAddress();
   }
 
   async rotateVanillaAddress(): Promise<string> {
-    return this.wallet.rotate_address(0);
+    return this.wallet.rotateAddress(1);
   }
 
   async rotateColoredAddress(): Promise<string> {
-    return this.wallet.rotate_address(1);
+    return this.wallet.rotateAddress(0);
   }
 
   // ─── Unspents ───────────────────────────────────────────────────────────────
 
   async listUnspents(): Promise<Unspent[]> {
-    const raw: any[] = this.wallet.list_unspents(false) as any[];
+    const raw: any[] = this.wallet.listUnspents(false) as any[];
     return raw.map((unspent) => {
       const rgbAllocs = unspent.rgb_allocations ?? unspent.rgbAllocations ?? [];
       return {
@@ -531,7 +540,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     params: CreateUtxosBeginRequestModel
   ): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.create_utxos_begin(
+    return this.wallet.createUtxosBegin(
       online,
       params.upTo ?? false,
       params.num ?? undefined,
@@ -543,7 +552,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async createUtxosEnd(params: CreateUtxosEndRequestModel): Promise<number> {
     const online = await this.ensureOnline();
-    return this.wallet.create_utxos_end(
+    return this.wallet.createUtxosEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -586,26 +595,28 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     const transportEndpoints = (raw.transport_endpoints ??
       raw.transportEndpoints) as string[] | undefined;
 
-    const witnessData: WasmRecipient['witness_data'] =
+    const witnessData: WasmRecipient['witnessData'] =
       params.witnessData != null
         ? {
-            amount_sat: String(params.witnessData.amountSat),
+            amountSat: String(params.witnessData.amountSat),
             blinding: params.witnessData.blinding ?? null,
           }
         : null;
 
     const recipient: WasmRecipient = {
-      recipient_id: String(raw.recipient_id ?? raw.recipientId ?? ''),
-      witness_data: witnessData,
+      recipientId: String(raw.recipient_id ?? raw.recipientId ?? ''),
+      witnessData,
       assignment: { Fungible: amount },
-      transport_endpoints: transportEndpoints ?? [],
+      transportEndpoints: transportEndpoints ?? [],
     };
+
+    const recipientMap = { [assetId]: [recipient] } as WasmRecipientMap;
 
     const online = await this.ensureOnline();
 
-    return this.wallet.send_begin(
+    return this.wallet.sendBegin(
       online,
-      { [assetId]: [recipient] } as WasmRecipientMap,
+      recipientMap,
       params.donation ?? true,
       BigInt(Math.round(params.feeRate ?? 1)),
       params.minConfirmations ?? 1
@@ -627,7 +638,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
       );
     }
 
-    return this.wallet.send_begin(
+    return this.wallet.sendBegin(
       online,
       sdkRecipientMapToWasm(params.recipientMap),
       params.donation ?? true,
@@ -638,7 +649,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendEnd(params: SendAssetEndRequestModel): Promise<SendResult> {
     const online = await this.ensureOnline();
-    const raw = await this.wallet.send_end(
+    const raw = await this.wallet.sendEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -650,7 +661,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendBtcBegin(params: SendBtcBeginRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.send_btc_begin(
+    return this.wallet.sendBtcBegin(
       online,
       params.address,
       BigInt(Math.round(params.amount)),
@@ -661,7 +672,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async sendBtcEnd(params: SendBtcEndRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.send_btc_end(
+    return this.wallet.sendBtcEnd(
       online,
       params.signedPsbt,
       params.skipSync ?? false
@@ -674,7 +685,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     const assignment =
       params.amount != null ? { Fungible: params.amount } : 'Any';
 
-    const raw: unknown = this.wallet.blind_receive(
+    const raw: unknown = this.wallet.blindReceive(
       params.assetId ?? null,
       assignment,
       params.durationSeconds ?? null,
@@ -687,7 +698,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   async witnessReceive(params: InvoiceRequest): Promise<InvoiceReceiveData> {
     const assignment =
       params.amount != null ? { Fungible: params.amount } : 'Any';
-    const raw: unknown = this.wallet.witness_receive(
+    const raw: unknown = this.wallet.witnessReceive(
       params.assetId || null,
       assignment,
       params.durationSeconds ?? null,
@@ -726,12 +737,12 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   // ─── Assets ─────────────────────────────────────────────────────────────────
 
   async listAssets(): Promise<ListAssets> {
-    const raw = this.wallet.list_assets([]);
+    const raw = this.wallet.listAssets([]);
     return normalizeListAssets(raw);
   }
 
   async getAssetBalance(assetId: string): Promise<AssetBalance> {
-    const balance: Record<string, unknown> = this.wallet.get_asset_balance(
+    const balance: Record<string, unknown> = this.wallet.getAssetBalance(
       assetId
     ) as Record<string, unknown>;
     return {
@@ -748,7 +759,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async issueAssetNia(params: IssueAssetNiaRequestModel): Promise<AssetNIA> {
-    const raw = this.wallet.issue_asset_nia(
+    const raw = this.wallet.issueAssetNia(
       params.ticker,
       params.name,
       params.precision,
@@ -758,7 +769,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async issueAssetIfa(params: IssueAssetIfaRequestModel): Promise<AssetIfa> {
-    const raw = this.wallet.issue_asset_ifa(
+    const raw = this.wallet.issueAssetIfa(
       params.ticker,
       params.name,
       params.precision,
@@ -773,7 +784,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async inflateBegin(params: InflateAssetIfaRequestModel): Promise<string> {
     const online = await this.ensureOnline();
-    return this.wallet.inflate_begin(
+    return this.wallet.inflateBegin(
       online,
       params.assetId,
       params.inflationAmounts,
@@ -784,19 +795,19 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async inflateEnd(params: InflateEndRequestModel): Promise<OperationResult> {
     const online = await this.ensureOnline();
-    const raw = await this.wallet.inflate_end(online, params.signedPsbt);
+    const raw = await this.wallet.inflateEnd(online, params.signedPsbt);
     return normalizeBatchTxResult(raw);
   }
 
   // ─── Transfers & transactions ────────────────────────────────────────────────
 
   async listTransactions(): Promise<Transaction[]> {
-    const raw = this.wallet.list_transactions() as Record<string, unknown>[];
+    const raw = this.wallet.listTransactions() as Record<string, unknown>[];
     return raw.map((t) => normalizeTransaction(t));
   }
 
   async listTransfers(assetId?: string): Promise<Transfer[]> {
-    const raw = this.wallet.list_transfers(assetId ?? null) as Record<
+    const raw = this.wallet.listTransfers(assetId ?? null) as Record<
       string,
       unknown
     >[];
@@ -805,7 +816,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async failTransfers(params: FailTransfersRequest): Promise<boolean> {
     const online = await this.ensureOnline();
-    return this.wallet.fail_transfers(
+    return this.wallet.failTransfers(
       online,
       params.batchTransferIdx ?? null,
       params.noAssetOnly ?? false,
@@ -817,7 +828,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
     batchTransferIdx?: number;
     noAssetOnly?: boolean;
   }): boolean {
-    return this.wallet.delete_transfers(
+    return this.wallet.deleteTransfers(
       params.batchTransferIdx ?? null,
       params.noAssetOnly ?? false
     );
@@ -827,8 +838,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
 
   async refreshWallet(): Promise<void> {
     const online = await this.ensureOnline();
-    const refreshed = await this.wallet.refresh(online, null, [], false);
-    return refreshed;
+    await this.wallet.refresh(online, null, [], false);
   }
 
   async syncWallet(): Promise<void> {
@@ -843,7 +853,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }): Promise<GetFeeEstimationResponse> {
     const online = await this.ensureOnline();
     try {
-      return await this.wallet.get_fee_estimation(online, params.blocks);
+      return await this.wallet.getFeeEstimation(online, params.blocks);
     } catch {
       logger.warn(
         'WasmRgbLibBinding: fee estimation unavailable, using default 2'
@@ -883,13 +893,13 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
    * WASM-specific: restore wallet state from raw backup bytes.
    */
   restoreFromBackupBytes(bytes: Uint8Array, password: string): void {
-    this.wallet.restore_backup(bytes, password);
+    this.wallet.restoreBackup(bytes, password);
   }
 
   // ─── VSS backup ─────────────────────────────────────────────────────────────
 
   configureVssBackup(config: VssBackupConfig): void {
-    this.wallet.configure_vss_backup(
+    this.wallet.configureVssBackup(
       config.serverUrl,
       config.storeId,
       config.signingKey
@@ -897,17 +907,16 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   disableVssAutoBackup(): void {
-    this.wallet.disable_vss_backup();
+    this.wallet.disableVssBackup();
   }
 
   async vssBackup(_config: VssBackupConfig): Promise<number> {
-    // Config must already be set via configureVssBackup before calling.
-    const version = await this.wallet.vss_backup();
+    const version = await this.wallet.vssBackup();
     return Number(version);
   }
 
   async vssBackupInfo(_config: VssBackupConfig): Promise<VssBackupInfo> {
-    const info: any = await this.wallet.vss_backup_info();
+    const info: any = await this.wallet.vssBackupInfo();
     return {
       backupExists: Boolean(info.backup_exists ?? info.backupExists),
       serverVersion: info.server_version ?? info.serverVersion ?? null,
@@ -916,7 +925,7 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
   }
 
   async vssRestoreBackup(): Promise<void> {
-    await this.wallet.vss_restore_backup();
+    await this.wallet.vssRestoreBackup();
   }
 
   // ─── PSBT signing (built-in) ─────────────────────────────────────────────────
@@ -926,10 +935,10 @@ export class WasmRgbLibBinding implements IRgbLibBinding {
    * Called by WasmSigner.signPsbtWithMnemonic (Phase 3).
    */
   signPsbt(unsignedPsbt: string): string {
-    return this.wallet.sign_psbt(unsignedPsbt);
+    return this.wallet.signPsbt(unsignedPsbt);
   }
 
   finalizePsbt(signedPsbt: string): string {
-    return this.wallet.finalize_psbt(signedPsbt);
+    return this.wallet.finalizePsbt(signedPsbt);
   }
 }

--- a/src/binding/WasmTypes.ts
+++ b/src/binding/WasmTypes.ts
@@ -2,11 +2,8 @@
  * Supplemental TypeScript types for rgb-lib WASM bindings.
  *
  * The generated `rgb_lib_wasm_bindings.d.ts` uses `any` for JSON-shaped values.
- * These definitions match the default Rust build **without** the `camel_case` Cargo feature
- * (JSON field names use **snake_case**: `recipient_id`, `data_dir`, …).
- *
- * If you compile `rgb-lib-wasm` with `--features camel_case`, enable the alternate names
- * by passing `RgbLibJsonFieldStyle` (see below) or duplicate these interfaces with camelCase fields.
+ * These definitions match the build compiled with the `camel_case` Cargo feature
+ * (JSON field names use **camelCase**: `recipientId`, `dataDir`, …).
  *
  * u64 values crossing the WASM boundary may be `number` or `bigint` depending on magnitude
  * (serde_wasm_bindgen uses BigInt for large integers).
@@ -65,24 +62,25 @@ export type TransportType = 'JsonRpc';
 // ---------------------------------------------------------------------------
 
 export interface WalletData {
-  data_dir: string;
-  bitcoin_network: BitcoinNetworkName;
-  database_type: DatabaseType;
-  max_allocations_per_utxo: number;
-  account_xpub_vanilla: string;
-  account_xpub_colored: string;
+  dataDir: string;
+  bitcoinNetwork: BitcoinNetworkName;
+  databaseType: DatabaseType;
+  maxAllocationsPerUtxo: number;
+  accountXpubVanilla: string;
+  accountXpubColored: string;
   mnemonic: string | null;
-  master_fingerprint: string;
-  vanilla_keychain: number | null;
-  supported_schemas: AssetSchema[];
+  masterFingerprint: string;
+  vanillaKeychain: number | null;
+  reuseAddresses: boolean;
+  supportedSchemas: AssetSchema[];
 }
 
 export interface Keys {
   mnemonic: string;
   xpub: string;
-  account_xpub_vanilla: string;
-  account_xpub_colored: string;
-  master_fingerprint: string;
+  accountXpubVanilla: string;
+  accountXpubColored: string;
+  masterFingerprint: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,27 +89,27 @@ export interface Keys {
 
 export interface Online {
   id: number | bigint;
-  indexer_url: string;
+  indexerUrl: string;
 }
 
 export interface OperationResult {
   txid: string;
-  batch_transfer_idx: number;
+  batchTransferIdx: number;
 }
 
 export interface WitnessData {
-  amount_sat: number | bigint | string;
+  amountSat: number | bigint | string;
   blinding: number | bigint | null;
 }
 
 export interface Recipient {
-  recipient_id: string;
-  witness_data: WitnessData | null;
+  recipientId: string;
+  witnessData: WitnessData | null;
   assignment: AssignmentJson;
-  transport_endpoints: string[];
+  transportEndpoints: string[];
 }
 
-/** Map: asset_id → list of recipients (input to `send_begin`). */
+/** Map: assetId → list of recipients (input to `sendBegin`). */
 export type RecipientMap = Record<string, Recipient[]>;
 
 export interface RefreshFilter {
@@ -123,7 +121,7 @@ export interface RefreshFilter {
 export type RgbLibErrorJson = Record<string, unknown>;
 
 export interface RefreshedTransfer {
-  updated_status: TransferStatus | null;
+  updatedStatus: TransferStatus | null;
   failure: RgbLibErrorJson | null;
 }
 
@@ -146,51 +144,51 @@ export interface BtcBalance {
 }
 
 export interface Media {
-  file_path: string;
+  filePath: string;
   digest: string;
   mime: string;
 }
 
 export interface Metadata {
-  asset_schema: AssetSchema;
-  initial_supply: number | bigint;
-  max_supply: number | bigint;
-  known_circulating_supply: number | bigint;
+  assetSchema: AssetSchema;
+  initialSupply: number | bigint;
+  maxSupply: number | bigint;
+  knownCirculatingSupply: number | bigint;
   timestamp: number;
   name: string;
   precision: number;
   ticker: string | null;
   details: string | null;
-  reject_list_url: string | null;
+  rejectListUrl: string | null;
 }
 
 export interface AssetNIA {
-  asset_id: string;
+  assetId: string;
   ticker: string;
   name: string;
   details: string | null;
   precision: number;
-  issued_supply: number | bigint;
+  issuedSupply: number | bigint;
   timestamp: number;
-  added_at: number;
+  addedAt: number;
   balance: Balance;
   media: Media | null;
 }
 
 export interface AssetIFA {
-  asset_id: string;
+  assetId: string;
   ticker: string;
   name: string;
   details: string | null;
   precision: number;
-  initial_supply: number | bigint;
-  max_supply: number | bigint;
-  known_circulating_supply: number | bigint;
+  initialSupply: number | bigint;
+  maxSupply: number | bigint;
+  knownCirculatingSupply: number | bigint;
   timestamp: number;
-  added_at: number;
+  addedAt: number;
   balance: Balance;
   media: Media | null;
-  reject_list_url: string | null;
+  rejectListUrl: string | null;
 }
 
 export interface Assets {
@@ -204,20 +202,20 @@ export interface Assets {
 
 export interface ReceiveData {
   invoice: string;
-  recipient_id: string;
-  expiration_timestamp: number | null;
-  batch_transfer_idx: number;
+  recipientId: string;
+  expirationTimestamp: number | null;
+  batchTransferIdx: number;
 }
 
 export interface InvoiceData {
-  recipient_id: string;
-  asset_schema: AssetSchema | null;
-  asset_id: string | null;
+  recipientId: string;
+  assetSchema: AssetSchema | null;
+  assetId: string | null;
   assignment: AssignmentJson;
-  assignment_name: string | null;
+  assignmentName: string | null;
   network: BitcoinNetworkName;
-  expiration_timestamp: number | null;
-  transport_endpoints: string[];
+  expirationTimestamp: number | null;
+  transportEndpoints: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -235,56 +233,56 @@ export interface BlockTime {
 }
 
 export interface Transaction {
-  transaction_type: TransactionType;
+  transactionType: TransactionType;
   txid: string;
   received: number | bigint;
   sent: number | bigint;
   fee: number | bigint;
-  confirmation_time: BlockTime | null;
+  confirmationTime: BlockTime | null;
 }
 
 export interface TransferTransportEndpoint {
   endpoint: string;
-  transport_type: TransportType;
+  transportType: TransportType;
   used: boolean;
 }
 
 export interface Transfer {
   idx: number;
-  batch_transfer_idx: number;
-  created_at: number;
-  updated_at: number;
+  batchTransferIdx: number;
+  createdAt: number;
+  updatedAt: number;
   status: TransferStatus;
-  requested_assignment: AssignmentJson | null;
+  requestedAssignment: AssignmentJson | null;
   assignments: AssignmentJson[];
   kind: TransferKind;
   txid: string | null;
-  recipient_id: string | null;
-  receive_utxo: Outpoint | null;
-  change_utxo: Outpoint | null;
+  recipientId: string | null;
+  receiveUtxo: Outpoint | null;
+  changeUtxo: Outpoint | null;
   expiration: number | null;
-  transport_endpoints: TransferTransportEndpoint[];
-  invoice_string: string | null;
-  consignment_path: string | null;
+  transportEndpoints: TransferTransportEndpoint[];
+  invoiceString: string | null;
+  consignmentPath: string | null;
 }
 
 export interface RgbAllocation {
-  asset_id: string | null;
+  assetId: string | null;
   assignment: AssignmentJson;
   settled: boolean;
 }
 
 export interface Utxo {
   outpoint: Outpoint;
-  btc_amount: number | bigint;
+  btcAmount: number | bigint;
   colorable: boolean;
   exists: boolean;
 }
 
 export interface Unspent {
   utxo: Utxo;
-  rgb_allocations: RgbAllocation[];
-  pending_blinded: number;
+  rgbAllocations: RgbAllocation[];
+  pendingBlinded: number;
 }
 
 /**
@@ -298,9 +296,20 @@ export type LocalOutput = Record<string, unknown>;
 // ---------------------------------------------------------------------------
 
 export interface VssBackupInfo {
-  backup_exists: boolean;
-  server_version: number | null;
-  backup_required: boolean;
+  backupExists: boolean;
+  serverVersion: number | null;
+  backupRequired: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Consignment validation (validateConsignmentOffchain)
+// ---------------------------------------------------------------------------
+
+export interface ConsignmentValidationResult {
+  valid: boolean;
+  warnings?: string[];
+  error?: string;
+  details?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/binding/WasmTypes.ts
+++ b/src/binding/WasmTypes.ts
@@ -74,6 +74,7 @@ export interface WalletData {
   mnemonic: string | null;
   master_fingerprint: string;
   vanilla_keychain: number | null;
+  reuse_addresses: boolean;
   supported_schemas: AssetSchema[];
 }
 

--- a/src/binding/WasmTypes.ts
+++ b/src/binding/WasmTypes.ts
@@ -2,11 +2,8 @@
  * Supplemental TypeScript types for rgb-lib WASM bindings.
  *
  * The generated `rgb_lib_wasm_bindings.d.ts` uses `any` for JSON-shaped values.
- * These definitions match the default Rust build **without** the `camel_case` Cargo feature
- * (JSON field names use **snake_case**: `recipient_id`, `data_dir`, …).
- *
- * If you compile `rgb-lib-wasm` with `--features camel_case`, enable the alternate names
- * by passing `RgbLibJsonFieldStyle` (see below) or duplicate these interfaces with camelCase fields.
+ * These definitions match the build compiled with the `camel_case` Cargo feature
+ * (JSON field names use **camelCase**: `recipientId`, `dataDir`, …).
  *
  * u64 values crossing the WASM boundary may be `number` or `bigint` depending on magnitude
  * (serde_wasm_bindgen uses BigInt for large integers).
@@ -65,25 +62,25 @@ export type TransportType = 'JsonRpc';
 // ---------------------------------------------------------------------------
 
 export interface WalletData {
-  data_dir: string;
-  bitcoin_network: BitcoinNetworkName;
-  database_type: DatabaseType;
-  max_allocations_per_utxo: number;
-  account_xpub_vanilla: string;
-  account_xpub_colored: string;
+  dataDir: string;
+  bitcoinNetwork: BitcoinNetworkName;
+  databaseType: DatabaseType;
+  maxAllocationsPerUtxo: number;
+  accountXpubVanilla: string;
+  accountXpubColored: string;
   mnemonic: string | null;
-  master_fingerprint: string;
-  vanilla_keychain: number | null;
-  reuse_addresses: boolean;
-  supported_schemas: AssetSchema[];
+  masterFingerprint: string;
+  vanillaKeychain: number | null;
+  reuseAddresses: boolean;
+  supportedSchemas: AssetSchema[];
 }
 
 export interface Keys {
   mnemonic: string;
   xpub: string;
-  account_xpub_vanilla: string;
-  account_xpub_colored: string;
-  master_fingerprint: string;
+  accountXpubVanilla: string;
+  accountXpubColored: string;
+  masterFingerprint: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,27 +89,27 @@ export interface Keys {
 
 export interface Online {
   id: number | bigint;
-  indexer_url: string;
+  indexerUrl: string;
 }
 
 export interface OperationResult {
   txid: string;
-  batch_transfer_idx: number;
+  batchTransferIdx: number;
 }
 
 export interface WitnessData {
-  amount_sat: number | bigint | string;
+  amountSat: number | bigint | string;
   blinding: number | bigint | null;
 }
 
 export interface Recipient {
-  recipient_id: string;
-  witness_data: WitnessData | null;
+  recipientId: string;
+  witnessData: WitnessData | null;
   assignment: AssignmentJson;
-  transport_endpoints: string[];
+  transportEndpoints: string[];
 }
 
-/** Map: asset_id → list of recipients (input to `send_begin`). */
+/** Map: assetId → list of recipients (input to `sendBegin`). */
 export type RecipientMap = Record<string, Recipient[]>;
 
 export interface RefreshFilter {
@@ -124,7 +121,7 @@ export interface RefreshFilter {
 export type RgbLibErrorJson = Record<string, unknown>;
 
 export interface RefreshedTransfer {
-  updated_status: TransferStatus | null;
+  updatedStatus: TransferStatus | null;
   failure: RgbLibErrorJson | null;
 }
 
@@ -147,51 +144,51 @@ export interface BtcBalance {
 }
 
 export interface Media {
-  file_path: string;
+  filePath: string;
   digest: string;
   mime: string;
 }
 
 export interface Metadata {
-  asset_schema: AssetSchema;
-  initial_supply: number | bigint;
-  max_supply: number | bigint;
-  known_circulating_supply: number | bigint;
+  assetSchema: AssetSchema;
+  initialSupply: number | bigint;
+  maxSupply: number | bigint;
+  knownCirculatingSupply: number | bigint;
   timestamp: number;
   name: string;
   precision: number;
   ticker: string | null;
   details: string | null;
-  reject_list_url: string | null;
+  rejectListUrl: string | null;
 }
 
 export interface AssetNIA {
-  asset_id: string;
+  assetId: string;
   ticker: string;
   name: string;
   details: string | null;
   precision: number;
-  issued_supply: number | bigint;
+  issuedSupply: number | bigint;
   timestamp: number;
-  added_at: number;
+  addedAt: number;
   balance: Balance;
   media: Media | null;
 }
 
 export interface AssetIFA {
-  asset_id: string;
+  assetId: string;
   ticker: string;
   name: string;
   details: string | null;
   precision: number;
-  initial_supply: number | bigint;
-  max_supply: number | bigint;
-  known_circulating_supply: number | bigint;
+  initialSupply: number | bigint;
+  maxSupply: number | bigint;
+  knownCirculatingSupply: number | bigint;
   timestamp: number;
-  added_at: number;
+  addedAt: number;
   balance: Balance;
   media: Media | null;
-  reject_list_url: string | null;
+  rejectListUrl: string | null;
 }
 
 export interface Assets {
@@ -205,20 +202,20 @@ export interface Assets {
 
 export interface ReceiveData {
   invoice: string;
-  recipient_id: string;
-  expiration_timestamp: number | null;
-  batch_transfer_idx: number;
+  recipientId: string;
+  expirationTimestamp: number | null;
+  batchTransferIdx: number;
 }
 
 export interface InvoiceData {
-  recipient_id: string;
-  asset_schema: AssetSchema | null;
-  asset_id: string | null;
+  recipientId: string;
+  assetSchema: AssetSchema | null;
+  assetId: string | null;
   assignment: AssignmentJson;
-  assignment_name: string | null;
+  assignmentName: string | null;
   network: BitcoinNetworkName;
-  expiration_timestamp: number | null;
-  transport_endpoints: string[];
+  expirationTimestamp: number | null;
+  transportEndpoints: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -236,56 +233,56 @@ export interface BlockTime {
 }
 
 export interface Transaction {
-  transaction_type: TransactionType;
+  transactionType: TransactionType;
   txid: string;
   received: number | bigint;
   sent: number | bigint;
   fee: number | bigint;
-  confirmation_time: BlockTime | null;
+  confirmationTime: BlockTime | null;
 }
 
 export interface TransferTransportEndpoint {
   endpoint: string;
-  transport_type: TransportType;
+  transportType: TransportType;
   used: boolean;
 }
 
 export interface Transfer {
   idx: number;
-  batch_transfer_idx: number;
-  created_at: number;
-  updated_at: number;
+  batchTransferIdx: number;
+  createdAt: number;
+  updatedAt: number;
   status: TransferStatus;
-  requested_assignment: AssignmentJson | null;
+  requestedAssignment: AssignmentJson | null;
   assignments: AssignmentJson[];
   kind: TransferKind;
   txid: string | null;
-  recipient_id: string | null;
-  receive_utxo: Outpoint | null;
-  change_utxo: Outpoint | null;
+  recipientId: string | null;
+  receiveUtxo: Outpoint | null;
+  changeUtxo: Outpoint | null;
   expiration: number | null;
-  transport_endpoints: TransferTransportEndpoint[];
-  invoice_string: string | null;
-  consignment_path: string | null;
+  transportEndpoints: TransferTransportEndpoint[];
+  invoiceString: string | null;
+  consignmentPath: string | null;
 }
 
 export interface RgbAllocation {
-  asset_id: string | null;
+  assetId: string | null;
   assignment: AssignmentJson;
   settled: boolean;
 }
 
 export interface Utxo {
   outpoint: Outpoint;
-  btc_amount: number | bigint;
+  btcAmount: number | bigint;
   colorable: boolean;
   exists: boolean;
 }
 
 export interface Unspent {
   utxo: Utxo;
-  rgb_allocations: RgbAllocation[];
-  pending_blinded: number;
+  rgbAllocations: RgbAllocation[];
+  pendingBlinded: number;
 }
 
 /**
@@ -299,9 +296,20 @@ export type LocalOutput = Record<string, unknown>;
 // ---------------------------------------------------------------------------
 
 export interface VssBackupInfo {
-  backup_exists: boolean;
-  server_version: number | null;
-  backup_required: boolean;
+  backupExists: boolean;
+  serverVersion: number | null;
+  backupRequired: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Consignment validation (validateConsignmentOffchain)
+// ---------------------------------------------------------------------------
+
+export interface ConsignmentValidationResult {
+  valid: boolean;
+  warnings?: string[];
+  error?: string;
+  details?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ export type {
 } from './crypto/signer';
 export type { GeneratedKeys, AccountXpubs } from '@utexo/rgb-sdk-core';
 
+// Consignment validation
+export { validateConsignmentOffchain } from './binding/WasmRgbLibBinding';
+
 // Function exports
 export { signPsbt, signPsbtFromSeed, estimatePsbt } from './crypto/signer';
 export {

--- a/src/utexo/utexo-wallet.ts
+++ b/src/utexo/utexo-wallet.ts
@@ -25,6 +25,7 @@ export class UTEXOWallet extends UTEXOWalletCore {
       masterFingerprint: utexoKeys.masterFingerprint,
       network: this.networkMap.utexo,
       mnemonic: this.mnemonicOrSeed as string,
+      reuseAddresses: this.options.reuseAddresses,
     });
 
     this.layer1Wallet = await WalletManager.create({

--- a/src/wallet/wallet-manager.ts
+++ b/src/wallet/wallet-manager.ts
@@ -46,6 +46,9 @@ export class WalletManager extends BaseWalletManager {
       network: String(params.network ?? 'regtest'),
       transportEndpoint: params.transportEndpoint,
       indexerUrl: params.indexerUrl,
+      reuseAddresses: params.reuseAddresses,
+      vanillaKeychain: params.vanillaKeychain,
+      maxAllocationsPerUtxo: params.maxAllocationsPerUtxo,
     });
 
     return new WalletManager(params, client);

--- a/tests/__mocks__/rgb-lib-wasm.ts
+++ b/tests/__mocks__/rgb-lib-wasm.ts
@@ -7,9 +7,11 @@ import { jest } from '@jest/globals';
 export const mockWasmWalletInstance = {
   free: jest.fn(),
   get_address: jest.fn().mockReturnValue('tb1qmock'),
-  rotate_address: jest.fn().mockImplementation((keychain: number) =>
-    keychain === 0 ? 'tb1qvanilla' : 'tb1qcolored'
-  ),
+  rotate_address: jest
+    .fn()
+    .mockImplementation((keychain: number) =>
+      keychain === 0 ? 'tb1qvanilla' : 'tb1qcolored'
+    ),
   get_btc_balance: jest.fn().mockReturnValue({
     vanilla: { settled: 0, future: 0, spendable: 0 },
     colored: { settled: 0, future: 0, spendable: 0 },

--- a/tests/__mocks__/rgb-lib-wasm.ts
+++ b/tests/__mocks__/rgb-lib-wasm.ts
@@ -1,0 +1,55 @@
+/**
+ * Manual mock for @utexo/rgb-lib-wasm — used by Jest to avoid loading the
+ * actual WASM binary (which requires a browser fetch environment).
+ */
+import { jest } from '@jest/globals';
+
+export const mockWasmWalletInstance = {
+  free: jest.fn(),
+  get_address: jest.fn().mockReturnValue('tb1qmock'),
+  rotate_address: jest.fn().mockImplementation((keychain: number) =>
+    keychain === 0 ? 'tb1qvanilla' : 'tb1qcolored'
+  ),
+  get_btc_balance: jest.fn().mockReturnValue({
+    vanilla: { settled: 0, future: 0, spendable: 0 },
+    colored: { settled: 0, future: 0, spendable: 0 },
+  }),
+  go_online: jest.fn().mockResolvedValue({ id: 1, indexer_url: '' }),
+  backup: jest.fn().mockReturnValue(new Uint8Array()),
+  sign_psbt: jest.fn().mockReturnValue('signed'),
+  finalize_psbt: jest.fn().mockReturnValue('finalized'),
+};
+
+export let lastCreatedWalletData: Record<string, unknown> | null = null;
+
+export const WasmWallet = {
+  create: jest.fn().mockImplementation(async (json: string) => {
+    lastCreatedWalletData = JSON.parse(json);
+    return mockWasmWalletInstance;
+  }),
+};
+
+export const WasmInvoice = jest.fn().mockImplementation(() => ({
+  invoiceData: jest.fn().mockReturnValue({}),
+  free: jest.fn(),
+}));
+
+export const generate_keys = jest.fn().mockReturnValue({
+  mnemonic: 'test mnemonic',
+  xpub: 'tpub...',
+  account_xpub_vanilla: 'tpub...',
+  account_xpub_colored: 'tpub...',
+  master_fingerprint: '00000000',
+});
+
+export const restore_keys = jest.fn().mockReturnValue({
+  mnemonic: 'test mnemonic',
+  xpub: 'tpub...',
+  account_xpub_vanilla: 'tpub...',
+  account_xpub_colored: 'tpub...',
+  master_fingerprint: '00000000',
+});
+
+// Default export is the WASM init function — called by src/wasm/init.ts
+const initWasmModule = jest.fn().mockResolvedValue(undefined);
+export default initWasmModule;

--- a/tests/wallet-init-params.test.ts
+++ b/tests/wallet-init-params.test.ts
@@ -14,7 +14,10 @@ jest.mock('../src/wasm/init.ts', () => ({
 }));
 
 import { WasmRgbLibBinding } from '../src/binding/WasmRgbLibBinding';
-import { lastCreatedWalletData, mockWasmWalletInstance } from './__mocks__/rgb-lib-wasm';
+import {
+  lastCreatedWalletData,
+  mockWasmWalletInstance,
+} from './__mocks__/rgb-lib-wasm';
 
 const baseParams = {
   xpubVan:
@@ -82,7 +85,10 @@ describe('WasmRgbLibBinding — maxAllocationsPerUtxo', () => {
   });
 
   it('passes max_allocations_per_utxo: 10', async () => {
-    await WasmRgbLibBinding.create({ ...baseParams, maxAllocationsPerUtxo: 10 });
+    await WasmRgbLibBinding.create({
+      ...baseParams,
+      maxAllocationsPerUtxo: 10,
+    });
     expect(getWalletData().max_allocations_per_utxo).toBe(10);
   });
 });

--- a/tests/wallet-init-params.test.ts
+++ b/tests/wallet-init-params.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for new optional WalletInitParams fields:
+ * reuseAddresses, vanillaKeychain, maxAllocationsPerUtxo
+ *
+ * @utexo/rgb-lib-wasm is redirected to a manual mock via moduleNameMapper
+ * so the WASM binary is never loaded.
+ */
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+// Mock initWasm so WasmRgbLibBinding.create() doesn't try to fetch the WASM binary
+jest.mock('../src/wasm/init.ts', () => ({
+  initWasm: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { WasmRgbLibBinding } from '../src/binding/WasmRgbLibBinding';
+import { lastCreatedWalletData, mockWasmWalletInstance } from './__mocks__/rgb-lib-wasm';
+
+const baseParams = {
+  xpubVan:
+    'tpubDDTg3fRGqAvEvshRUUwuS8brXkewNsE6y6Jbb9xZcuzBbmxAWa3UCmwyQG4peM9RwjgY8BDwuRVRU5KGtvRby5kiv1dk13YHU8z39o18QJK',
+  xpubCol:
+    'tpubDDqoEexZxewBLjXmZ7kxSHgZgmdAtej6DrXLBMiSSuPCdGQqjkTvyETLLVY7qNpxNRGUivvxDj8sswHHihT5effNNDmsbMUX2Lrpy4zjRcS',
+  masterFingerprint: '42424232',
+  mnemonic:
+    'flight seminar tray bulb level embody switch enhance august deny scene dismiss',
+  network: 'regtest',
+};
+
+function getWalletData() {
+  return lastCreatedWalletData as Record<string, unknown>;
+}
+
+describe('WasmRgbLibBinding — reuseAddresses', () => {
+  it('defaults reuse_addresses to false when not provided', async () => {
+    await WasmRgbLibBinding.create(baseParams);
+    expect(getWalletData().reuse_addresses).toBe(false);
+  });
+
+  it('passes reuse_addresses: true when reuseAddresses: true', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, reuseAddresses: true });
+    expect(getWalletData().reuse_addresses).toBe(true);
+  });
+
+  it('passes reuse_addresses: false when reuseAddresses: false', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, reuseAddresses: false });
+    expect(getWalletData().reuse_addresses).toBe(false);
+  });
+});
+
+describe('WasmRgbLibBinding — vanillaKeychain', () => {
+  it('defaults vanilla_keychain to 0 when not provided', async () => {
+    await WasmRgbLibBinding.create(baseParams);
+    expect(getWalletData().vanilla_keychain).toBe(0);
+  });
+
+  it('passes vanilla_keychain: 0 when vanillaKeychain: 0', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, vanillaKeychain: 0 });
+    expect(getWalletData().vanilla_keychain).toBe(0);
+  });
+
+  it('passes vanilla_keychain: null when vanillaKeychain: null', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, vanillaKeychain: null });
+    expect(getWalletData().vanilla_keychain).toBeNull();
+  });
+
+  it('passes custom vanilla_keychain value', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, vanillaKeychain: 2 });
+    expect(getWalletData().vanilla_keychain).toBe(2);
+  });
+});
+
+describe('WasmRgbLibBinding — maxAllocationsPerUtxo', () => {
+  it('defaults max_allocations_per_utxo to 5 when not provided', async () => {
+    await WasmRgbLibBinding.create(baseParams);
+    expect(getWalletData().max_allocations_per_utxo).toBe(5);
+  });
+
+  it('passes custom max_allocations_per_utxo value', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, maxAllocationsPerUtxo: 1 });
+    expect(getWalletData().max_allocations_per_utxo).toBe(1);
+  });
+
+  it('passes max_allocations_per_utxo: 10', async () => {
+    await WasmRgbLibBinding.create({ ...baseParams, maxAllocationsPerUtxo: 10 });
+    expect(getWalletData().max_allocations_per_utxo).toBe(10);
+  });
+});
+
+describe('WasmRgbLibBinding — rotateVanillaAddress / rotateColoredAddress', () => {
+  it('rotateVanillaAddress calls wallet.rotate_address(0)', async () => {
+    const binding = await WasmRgbLibBinding.create(baseParams);
+    const addr = await binding.rotateVanillaAddress();
+    expect(mockWasmWalletInstance.rotate_address).toHaveBeenCalledWith(0);
+    expect(addr).toBe('tb1qvanilla');
+  });
+
+  it('rotateColoredAddress calls wallet.rotate_address(1)', async () => {
+    const binding = await WasmRgbLibBinding.create(baseParams);
+    const addr = await binding.rotateColoredAddress();
+    expect(mockWasmWalletInstance.rotate_address).toHaveBeenCalledWith(1);
+    expect(addr).toBe('tb1qcolored');
+  });
+});


### PR DESCRIPTION
- `WalletInitParams.reuseAddresses` — optional `boolean` (default `false`); passed to `WasmWallet` as `reuse_addresses` to pin addresses per keychain instead of rotating automatically
- `WalletInitParams.vanillaKeychain` — optional `number | null` (default `0`); controls the BIP32 keychain index used for the vanilla (BTC) wallet
- `WalletInitParams.maxAllocationsPerUtxo` — optional `number` (default `5`); forwarded to `WasmWallet` as `max_allocations_per_utxo`
- `WasmRgbLibBinding.rotateVanillaAddress()` — rotates the pinned vanilla address (`rotate_address(0)`); requires wallet created with `reuseAddresses: true`
- `WasmRgbLibBinding.rotateColoredAddress()` — rotates the pinned colored address (`rotate_address(1)`); requires wallet created with `reuseAddresses: true`
- `WalletManager` forwards all three new params to `WasmRgbLibBinding.create()`
- Jest test suite (`tests/wallet-init-params.test.ts`) covering default values and forwarding of all new fields, plus `rotateVanillaAddress` / `rotateColoredAddress` behavior
