### PR TITLE
fix(rln): use callers indexerUrl for LN node chain-sync

### DIFF
--- a/src/binding/RlnDefaults.ts
+++ b/src/binding/RlnDefaults.ts
@@ -60,7 +60,8 @@ export function resolveNodeIndexerUrl(
   indexerUrl?: string
 ): string {
   if (indexerUrl) return indexerUrl;
-  const defaultIndexerUrl = CORE_DEFAULT_INDEXER_URLS[normalizeNetwork(network)];
+  const defaultIndexerUrl =
+    CORE_DEFAULT_INDEXER_URLS[normalizeNetwork(network)];
   if (!defaultIndexerUrl) {
     throw new ValidationError(
       `No indexer URL configured for network "${network}" — pass indexerUrl explicitly`,

--- a/src/binding/RlnDefaults.ts
+++ b/src/binding/RlnDefaults.ts
@@ -1,4 +1,9 @@
 import type { Network } from '@utexo/rgb-sdk-core';
+import {
+  DEFAULT_INDEXER_URLS as CORE_DEFAULT_INDEXER_URLS,
+  normalizeNetwork,
+  ValidationError,
+} from '@utexo/rgb-sdk-core';
 
 export interface RlnNetworkUrls {
   /** WebSocket proxy URL for the Lightning node */
@@ -43,6 +48,26 @@ export const DEFAULT_RLN_URLS: Partial<Record<Network, RlnNetworkUrls>> = {
 
 export function getRlnUrls(network: string): RlnNetworkUrls | undefined {
   return (DEFAULT_RLN_URLS as Record<string, RlnNetworkUrls>)[network];
+}
+
+/**
+ * Effective esplora indexer for both the wallet go-online default and the LN
+ * node's chain-sync. A non-empty `indexerUrl` wins; otherwise the network
+ * default is used. Throws if neither is available (never silently guesses).
+ */
+export function resolveNodeIndexerUrl(
+  network: string,
+  indexerUrl?: string
+): string {
+  if (indexerUrl) return indexerUrl;
+  const defaultIndexerUrl = CORE_DEFAULT_INDEXER_URLS[normalizeNetwork(network)];
+  if (!defaultIndexerUrl) {
+    throw new ValidationError(
+      `No indexer URL configured for network "${network}" — pass indexerUrl explicitly`,
+      'indexerUrl'
+    );
+  }
+  return defaultIndexerUrl;
 }
 
 // ── Moved to @utexo/rgb-sdk-core ─────────────────────────────────────────────

--- a/src/binding/RlnWasmBinding.ts
+++ b/src/binding/RlnWasmBinding.ts
@@ -23,10 +23,9 @@ import {
   WalletError,
   ValidationError,
   logger,
-  normalizeNetwork,
   normalizeRlnNetwork,
 } from '@utexo/rgb-sdk-core';
-import { DEFAULT_INDEXER_URLS } from './RlnDefaults';
+import { resolveNodeIndexerUrl } from './RlnDefaults';
 import type { IRlnSdkBinding } from '../rln';
 import type { IRlnNodeBinding } from '../rln';
 import type {
@@ -116,6 +115,10 @@ export interface RlnBindingCreateParams {
   proxyUrl?: string;
   /** RGB proxy transport endpoint (HTTP) — passed to sdk.setDefaultRgbProxyTransport */
   transportEndpoint?: string;
+  /** Esplora HTTP indexer for the wallet go-online default and the LN node's
+   *  chain-sync. Omitted → the network default. Must be http(s) — the wasm
+   *  chain-sync rejects other schemes. */
+  indexerUrl?: string;
   /** stable runtime ID for persistent node state across reloads */
   nodeRuntimeId?: string;
   /** WS gateway relay auth (appended as auth_token/node_id query params on
@@ -557,9 +560,10 @@ export class RlnWasmBinding implements IRlnSdkBinding {
       }
       rlnNode = new RlnNodeBinding(nodeHandle);
     }
-    const normalizedNet = normalizeNetwork(params.network);
-    const defaultIndexerUrl =
-      DEFAULT_INDEXER_URLS[normalizedNet] ?? DEFAULT_INDEXER_URLS.utexo;
+    const defaultIndexerUrl = resolveNodeIndexerUrl(
+      params.network,
+      params.indexerUrl
+    );
 
     const binding = new RlnWasmBinding(
       sdk,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,11 @@ export { RlnWasmBinding } from './binding/RlnWasmBinding';
 export type { RlnBindingCreateParams } from './binding/RlnWasmBinding';
 
 // RLN network defaults
-export { DEFAULT_RLN_URLS, getRlnUrls } from './binding/RlnDefaults';
+export {
+  DEFAULT_RLN_URLS,
+  getRlnUrls,
+  resolveNodeIndexerUrl,
+} from './binding/RlnDefaults';
 export type { RlnNetworkUrls } from './binding/RlnDefaults';
 export { getDefaultLspBaseUrl, resolveLspBaseUrl } from './binding/RlnDefaults';
 

--- a/src/wallet/rln-wallet-manager.ts
+++ b/src/wallet/rln-wallet-manager.ts
@@ -543,6 +543,7 @@ export class RlnWalletManager {
       vanillaKeychain: params.vanillaKeychain,
       proxyUrl,
       transportEndpoint,
+      indexerUrl,
       relayAuthToken,
       relayNodeId,
       nodeRuntimeId: params.nodeRuntimeId,

--- a/tests/indexer-url.test.ts
+++ b/tests/indexer-url.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveNodeIndexerUrl, DEFAULT_INDEXER_URLS } from '../dist/index.mjs';
+
+/**
+ * Regression guard for the signet chain-sync bug: the LN node used to ignore
+ * the constructor `indexerUrl` and always use the network default. A supplied
+ * URL must win; a missing one must resolve to the network default or throw.
+ */
+describe('resolveNodeIndexerUrl', () => {
+  it('returns the caller-supplied URL, overriding the network default', () => {
+    const custom = 'https://my-esplora.example.com';
+    expect(resolveNodeIndexerUrl('signet', custom)).toBe(custom);
+    expect(resolveNodeIndexerUrl('signet', custom)).not.toBe(
+      DEFAULT_INDEXER_URLS.signet
+    );
+  });
+
+  it('falls back to the per-network default when no URL is supplied', () => {
+    expect(resolveNodeIndexerUrl('signet')).toBe(DEFAULT_INDEXER_URLS.signet);
+    expect(resolveNodeIndexerUrl('testnet')).toBe(DEFAULT_INDEXER_URLS.testnet);
+    expect(resolveNodeIndexerUrl('utexo')).toBe(DEFAULT_INDEXER_URLS.utexo);
+  });
+
+  it('treats an empty string as "not supplied"', () => {
+    expect(resolveNodeIndexerUrl('signet', '')).toBe(
+      DEFAULT_INDEXER_URLS.signet
+    );
+  });
+
+  it('honours the supplied URL even for an unrecognised network', () => {
+    const custom = 'https://my-esplora.example.com';
+    expect(resolveNodeIndexerUrl('not-a-network', custom)).toBe(custom);
+  });
+
+  it('throws when no URL is supplied and none is configured', () => {
+    expect(() => resolveNodeIndexerUrl('not-a-network')).toThrow();
+  });
+});


### PR DESCRIPTION
The LN node's chain-sync ignored the constructor indexerUrl and always used the network default (broken ssl:// electrum on signet), freezing the tip. Now the caller's indexerUrl is threaded through so wallet go-online and node chain-sync share one URL, via a new resolveNodeIndexerUrl helper (caller wins -> network default -> throws if neither). 

Adds tests/indexer-url.test.ts.